### PR TITLE
feat: Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub's certified learning program. Part of our GitHub Certifications initiative for college applications.",
+        "schedule": "Mondays and Thursdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
Add GitHub Skills activity to the extracurricular activities list to address the time-sensitive student request.

## Context
This resolves issue #6 which reports that the GitHub Skills activity announced by the principal is missing from the registration system.

## Changes
- **Activity Name**: GitHub Skills
- **Description**: Learn practical coding and collaboration skills through GitHub's certified learning program. Part of our GitHub Certifications initiative for college applications.
- **Schedule**: Mondays and Thursdays, 3:30 PM - 4:30 PM
- **Capacity**: 25 participants

## Motivation
- Time-sensitive: students need to register by end of week
- Part of GitHub Certifications program for college applications
- Addresses student request from issue #6

## Closes
Closes #6